### PR TITLE
Commented reason for package name change

### DIFF
--- a/wireguard_install.sh
+++ b/wireguard_install.sh
@@ -3,7 +3,7 @@
 # Install packages
 opkg update
 
-The package name has changed
+#The package name has changed
 #opkg install wireguard
 opkg install wireguard-tools
  


### PR DESCRIPTION
Hi,

thanks for all the work! Awesome content. 

The proposed commit just fixes/comments the reason for the the package renaming. 
Otherwise, you get 
`./wireguard-install.sh: line 6: The: not found`